### PR TITLE
Implements default settings for database connections (Issue #3)/Creates a URI based off the defaults

### DIFF
--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -35,6 +35,5 @@ fn createuri() -> String{
     }else if urimaker.database_type == DatabaseType::Postgres {
         uri = format!("postgres://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
     } 
-    println!("{}", uri);
     return uri;
 }

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -1,0 +1,40 @@
+#[derive(Eq, PartialEq)]
+enum DatabaseType {
+    MySql,
+    Postgres,
+}
+struct ConnectionSettings {
+    database_type: DatabaseType,
+    username: String,
+    password: String,
+    hostname: String,
+    port: u16,
+    database_name: String,
+    use_tls: Option<bool>,
+}
+
+impl ConnectionSettings{
+    fn new() -> ConnectionSettings{
+        ConnectionSettings{
+            database_type: DatabaseType::MySql,
+            username: "".to_string(),
+            password: "".to_string(),
+            hostname: "localhost".to_string(),
+            port: 3306,
+            database_name: "".to_string(),
+            use_tls: None,
+        }
+    }
+}
+
+fn createuri() -> String{
+    let urimaker = ConnectionSettings::new();
+    let mut uri = "".to_string();
+    if urimaker.database_type == DatabaseType::MySql {
+        uri = format!("mysql://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
+    }else if urimaker.database_type == DatabaseType::Postgres {
+        uri = format!("postgres://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
+    } 
+    println!("{}", uri);
+    return uri;
+}

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -14,7 +14,7 @@ struct ConnectionSettings {
 }
 
 impl ConnectionSettings{
-    fn new() -> ConnectionSettings{
+    pub fn new() -> ConnectionSettings{
         ConnectionSettings{
             database_type: DatabaseType::MySql,
             username: "".to_string(),
@@ -25,15 +25,12 @@ impl ConnectionSettings{
             use_tls: None,
         }
     }
-    fn uri(&self) -> String {
-        //Hardcode in the username, password, and databasename, ect whatever is needed since those are not defaults
-        let mut uri = "".to_string();
-        //set the default protcall to mysql
-        let protocol = "mysql".to_string();
+    pub fn uri(&self) -> String {
+        // Hardcode in the username, password, and databasename, ect whatever is needed since those are not defaults.
+        let mut protocol = "mysql".to_string();
         if self.database_type == DatabaseType::Postgres {
-            let protocol = "postgres".to_string();
+            protocol = "postgres".to_string();
         }
-        uri = format!("{}://{}:{}@{}:{}/{}",protocol,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
-        return uri;
+        return format!("{}://{}:{}@{}:{}/{}",protocol,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
     }
 }

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -25,15 +25,15 @@ impl ConnectionSettings{
             use_tls: None,
         }
     }
-}
-
-fn createuri() -> String{
-    let urimaker = ConnectionSettings::new();
-    let mut uri = "".to_string();
-    if urimaker.database_type == DatabaseType::MySql {
-        uri = format!("mysql://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
-    }else if urimaker.database_type == DatabaseType::Postgres {
-        uri = format!("postgres://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
-    } 
-    return uri;
+    fn uri() -> String{
+        let urimaker = ConnectionSettings::new();
+        let mut uri = "".to_string();
+        if urimaker.database_type == DatabaseType::MySql {
+            uri = format!("mysql://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
+        }else if urimaker.database_type == DatabaseType::Postgres {
+            uri = format!("postgres://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
+        } 
+        println!("{}", uri);
+        return uri;
+    }
 }

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -29,11 +29,11 @@ impl ConnectionSettings{
         //Hardcode in the username, password, and databasename, ect whatever is needed since those are not defaults
         let mut uri = "".to_string();
         //set the default protcall to mysql
-        let protocall = "mysql".to_string();
+        let protocol = "mysql".to_string();
         if self.database_type == DatabaseType::Postgres {
-            let protocall = "postgres".to_string();
+            let protocol = "postgres".to_string();
         }
-        uri = format!("{}://{}:{}@{}:{}/{}",protocall,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
+        uri = format!("{}://{}:{}@{}:{}/{}",protocol,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
         return uri;
     }
 }

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -25,15 +25,15 @@ impl ConnectionSettings{
             use_tls: None,
         }
     }
-    fn uri() -> String{
-        let urimaker = ConnectionSettings::new();
+    fn uri(&self) -> String {
+        //Hardcode in the username, password, and databasename, ect whatever is needed since those are not defaults
         let mut uri = "".to_string();
-        if urimaker.database_type == DatabaseType::MySql {
-            uri = format!("mysql://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
-        }else if urimaker.database_type == DatabaseType::Postgres {
-            uri = format!("postgres://{}:{}@{}:{}/{}",urimaker.username,urimaker.password,urimaker.hostname,urimaker.port.to_string(),urimaker.database_name);
-        } 
-        println!("{}", uri);
+        //set the default protcall to mysql
+        let protocall = "mysql".to_string();
+        if self.database_type == DatabaseType::Postgres {
+            let protocall = "postgres".to_string();
+        }
+        uri = format!("{}://{}:{}@{}:{}/{}",protocall,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
         return uri;
     }
 }


### PR DESCRIPTION
For issue #3 
Creates default settings for the database connection (mysql or Postgress) and uses these to create a URI

- ConnectionSettings currently does not provide a username, password, and database_name yet (Leaves those defaults as blank just as settings.py does) (uri is currently: "mysql://:@localhost:3306/" because these are blank)
- createuri() creates a uri for either MySql or Postgres (currently the default is set to MySql, so that will be the one returned)


TODO: Figure out what will happen if a username/password is empty.