### PR TITLE
Refine cursor API to expose all query execution options.

### DIFF
--- a/packages/datajoint-core/Cargo.toml
+++ b/packages/datajoint-core/Cargo.toml
@@ -5,7 +5,5 @@ edition = "2018"
 repository = "https://github.com/datajoint/datajoint-core"
 
 [dependencies]
-futures = { version = "0.3.1" }
-futures-core = { version = "0.3.1" }
 tokio = { version = "1.11.0", features = ["full"] }
 sqlx = { version = "0.5", features = ["runtime-async-std-native-tls", "postgres", "mysql", "tls", "any"]}

--- a/packages/datajoint-core/src/connection/connection.rs
+++ b/packages/datajoint-core/src/connection/connection.rs
@@ -74,27 +74,4 @@ impl Connection {
             Some(pool) => Ok(Cursor::new(pool, &self.runtime)),
         }
     }
-
-    /// Creates a cursor for a raw query, given as a string, to execute over the connection.
-    ///
-    /// Panics on error.
-    pub fn raw_query<'c>(&'c self, query: &'c str) -> Cursor<'c> {
-        self.try_raw_query(query).unwrap()
-    }
-
-    // Creates a cursor for a raw query, given as a string, to execute over the connection.
-    pub fn try_raw_query<'c>(&'c self, query: &'c str) -> Result<Cursor<'c>, &str> {
-        self.runtime.block_on(self.raw_query_async(query))
-    }
-
-    async fn raw_query_async<'c>(&'c self, query: &'c str) -> Result<Cursor<'c>, &str> {
-        match &self.pool {
-            None => Err("error in query_async"),
-            Some(pool) => {
-                let mut cursor = Cursor::new(pool, &self.runtime);
-                cursor.execute(query);
-                Ok(cursor)
-            }
-        }
-    }
 }


### PR DESCRIPTION
Closes #16.

Refines how cursors are created and used for executing queries so that cursors are more flexible. Cursors no longer can execute queries row-by-row. Instead, they are executed once using either `execute`, `fetch_one`, or `fetch_all`. This makes cursors much more versatile.