### PR TITLE
Primitive enum checking for C FFI

### DIFF
--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -1,7 +1,13 @@
-#[derive(Eq, PartialEq)]
-pub enum DatabaseType {
-    MySql,
-    Postgres,
+use crate::util::generate_primitive_datajoint_enum;
+
+generate_primitive_datajoint_enum! {
+    #[doc="Type of database that can be connected to."]
+    #[repr(i32)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum DatabaseType {
+        MySql,
+        Postgres,
+    }
 }
 
 pub struct ConnectionSettings {
@@ -14,9 +20,9 @@ pub struct ConnectionSettings {
     pub use_tls: Option<bool>,
 }
 
-impl ConnectionSettings{
+impl ConnectionSettings {
     pub fn new() -> Self {
-        ConnectionSettings{
+        ConnectionSettings {
             database_type: DatabaseType::MySql,
             username: "".to_string(),
             password: "".to_string(),
@@ -32,6 +38,14 @@ impl ConnectionSettings{
         if self.database_type == DatabaseType::Postgres {
             protocol = "postgres".to_string();
         }
-        return format!("{}://{}:{}@{}:{}/{}",protocol,self.username,self.password,self.hostname,self.port.to_string(),self.database_name);
+        return format!(
+            "{}://{}:{}@{}:{}/{}",
+            protocol,
+            self.username,
+            self.password,
+            self.hostname,
+            self.port.to_string(),
+            self.database_name
+        );
     }
 }

--- a/packages/datajoint-core/src/error/codes.rs
+++ b/packages/datajoint-core/src/error/codes.rs
@@ -1,43 +1,46 @@
+use crate::util::generate_primitive_datajoint_enum;
 use std::fmt::{Display, Formatter, Result};
 
-/// Error codes for library-related errors. All internal errors are
-/// converted to one of these error codes so that the source of an error
-/// can be easily identified by users of the C FFI.
-///
-/// At the moment, these error codes are not standardized. In other words,
-/// the actual numeric value of the error may change at any time until
-/// a numbering system is standardized.
-#[repr(i32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ErrorCode {
-    Success = 0,
+generate_primitive_datajoint_enum! {
+    #[doc="Error codes for library-related errors. All internal errors are"]
+    #[doc="converted to one of these error codes so that the source of an error"]
+    #[doc="can be easily identified by users of the C FFI.\n"]
+    #[doc="At the moment, these error codes are not standardized. In other words,"]
+    #[doc="the actual numeric value of the error may change at any time until"]
+    #[doc="a numbering system is standardized."]
+    #[repr(i32)]
+    #[non_exhaustive]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum ErrorCode {
+        Success = 0,
 
-    // SQLx error codes.
-    ConfigurationError,
-    UnknownDatabaseError,
-    IoError,
-    TlsError,
-    ProtocolError,
-    RowNotFound,
-    TypeNotFound,
-    ColumnIndexOutOfBounds,
-    ColumnNotFound,
-    ColumnDecodeError,
-    ValueDecodeError,
-    PoolTimedOut,
-    PoolClosed,
-    WorkerCrashed,
-    UnknownSqlxError,
+        // SQLx error codes.
+        ConfigurationError,
+        UnknownDatabaseError,
+        IoError,
+        TlsError,
+        ProtocolError,
+        RowNotFound,
+        TypeNotFound,
+        ColumnIndexOutOfBounds,
+        ColumnNotFound,
+        ColumnDecodeError,
+        ValueDecodeError,
+        PoolTimedOut,
+        PoolClosed,
+        WorkerCrashed,
+        UnknownSqlxError,
 
-    // DataJoint error codes.
-    NotConnected,
-    NoMoreRows,
+        // DataJoint error codes.
+        NotConnected,
+        NoMoreRows,
 
-    // C FFI error codes.
-    NullNotAllowed,
-    BufferNotEnough,
-    InvalidNativeType,
+        // C FFI error codes.
+        NullNotAllowed,
+        BufferNotEnough,
+        InvalidNativeType,
+        InvalidEnumArgument,
+    }
 }
 
 impl Display for ErrorCode {

--- a/packages/datajoint-core/src/lib.rs
+++ b/packages/datajoint-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod connection;
 pub mod error;
 pub mod results;
 pub mod types;
+pub mod util;

--- a/packages/datajoint-core/src/types/types.rs
+++ b/packages/datajoint-core/src/types/types.rs
@@ -1,30 +1,34 @@
-/// Generalized types supported by DataJoint.
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum DataJointType {
-    Unknown,
-    TinyInt,
-    TinyIntUnsigned,
-    SmallInt,
-    SmallIntUnsigned,
-    MediumInt,
-    MediumIntUnsigned,
-    Int,
-    IntUnsigned,
-    Enum,
-    Date,
-    Time,
-    DateTime,
-    Timestamp,
-    CharN,
-    VarCharN,
-    Float,
-    Double,
-    Decimal,
-    TinyBlob,
-    MediumBlob,
-    Blob,
-    LongBlob,
-    Attach,
-    FilepathStore,
+use crate::util::generate_primitive_datajoint_enum;
+
+generate_primitive_datajoint_enum! {
+    #[doc="Generalized types supported by DataJoint."]
+    #[repr(i32)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum DataJointType {
+        Unknown,
+        TinyInt,
+        TinyIntUnsigned,
+        SmallInt,
+        SmallIntUnsigned,
+        MediumInt,
+        MediumIntUnsigned,
+        Int,
+        IntUnsigned,
+        Enum,
+        Date,
+        Time,
+        DateTime,
+        Timestamp,
+        CharN,
+        VarCharN,
+        Float,
+        Double,
+        Decimal,
+        TinyBlob,
+        MediumBlob,
+        Blob,
+        LongBlob,
+        Attach,
+        FilepathStore,
+    }
 }

--- a/packages/datajoint-core/src/util/enums.rs
+++ b/packages/datajoint-core/src/util/enums.rs
@@ -1,0 +1,24 @@
+pub(crate) mod enums {
+    macro_rules! generate_primitive_datajoint_enum {
+        ($(#[$meta:meta])* $vis:vis enum $name:ident {
+            $($(#[$vmeta:meta])* $vname:ident $(= $val:expr)?,)*
+        }) => {
+            $(#[$meta])*
+            $vis enum $name {
+                $($(#[$vmeta])* $vname $(= $val)?,)*
+            }
+
+            impl std::convert::TryFrom<i32> for $name {
+                type Error = ();
+                fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+                    match v {
+                        $(x if x == $name::$vname as i32 => Ok($name::$vname),)*
+                        _ => Err(()),
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) use generate_primitive_datajoint_enum;
+}

--- a/packages/datajoint-core/src/util/mod.rs
+++ b/packages/datajoint-core/src/util/mod.rs
@@ -1,0 +1,3 @@
+mod enums;
+
+pub(crate) use enums::enums::generate_primitive_datajoint_enum;


### PR DESCRIPTION
Support primitive enum conversion using macro generation for all cases.

Sample usage:
```rs
let value: i32 = ?
match DataJointType::try_from(value) {
    Ok(enum_value) => println!("Good: {:?}", enum_value),
    Err(_) => println!("error: {:?}", ErrorCode::InvalidEnumArgument),
}
```
