### PR TITLE
Adding SSL/TLS to URI connection string

### DIFF
--- a/packages/datajoint-core-ffi-c/src/connection/settings.rs
+++ b/packages/datajoint-core-ffi-c/src/connection/settings.rs
@@ -1,4 +1,4 @@
-use crate::util::boolenum::OptionalBool;
+use crate::util::OptionalBool;
 use datajoint_core::connection::{ConnectionSettings, DatabaseType};
 use libc::c_char;
 use std::ffi::{CStr, CString};
@@ -204,14 +204,13 @@ pub unsafe extern "C" fn connection_settings_get_use_tls(
     this: *const ConnectionSettings,
 ) -> OptionalBool {
     if this.is_null() {
-        // Problem is we won't be able to tell if this is null or is use_tls is actually None with this return
         return OptionalBool::None;
     }
     let connection: &ConnectionSettings = { &*this };
 
     match connection.use_tls {
-        Some(true) => return OptionalBool::True,
-        Some(false) => return OptionalBool::False,
-        None => return OptionalBool::None,
+        Some(true) => OptionalBool::True,
+        Some(false) => OptionalBool::False,
+        None => OptionalBool::None,
     }
 }

--- a/packages/datajoint-core-ffi-c/src/util/boolenum.rs
+++ b/packages/datajoint-core-ffi-c/src/util/boolenum.rs
@@ -1,4 +1,4 @@
-/// Generalized types supported by DataJoint.
+// Enum for setters and getters in connection/settings.rs. Used instead of a Option<bool>.
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum OptionalBool {

--- a/packages/datajoint-core-ffi-c/src/util/mod.rs
+++ b/packages/datajoint-core-ffi-c/src/util/mod.rs
@@ -1,4 +1,4 @@
+mod boolenum;
 mod strings;
-pub mod boolenum;
 
 pub use boolenum::OptionalBool;

--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -29,7 +29,6 @@ impl ConnectionSettings {
         }
     }
     pub fn uri(&self) -> String {
-        //getting warnings about these variables never being read before being overwritten, not sure how to avoid it here
         let mut protocol = String::new();
         let mut tls_ssl = String::new();
 
@@ -55,9 +54,9 @@ impl ConnectionSettings {
             self.database_name,
         );
         match self.use_tls {
-            Some(true) => return format!("{}?{}=true", uri, tls_ssl,),
-            Some(false) => return format!("{}?{}=false", uri, tls_ssl,),
-            None => return uri,
+            Some(true) => format!("{}?{}=true", uri, tls_ssl,),
+            Some(false) => format!("{}?{}=false", uri, tls_ssl,),
+            None => uri,
         }
     }
 }


### PR DESCRIPTION
Not sure if this is how it is done, plus I wasn't sure how to test it. Wanted to put it up as a draft so people could review it to see if anyone had any other ideas. Was kind of hard to find information on URI connection strings.

Changes Made:
- Changed from use_tls to Option<bool> since having a none in the uri would break it (What do y'all think?)
- Created new variable that is either tls or ssl depending on if it is a mysql or postgres
- Changed the uri to house tls/ssl now

Found information from

- [First answer here](https://stackoverflow.com/questions/22301722/ssl-for-postgresql-connection-nodejs)
- [Uri from the Example Collector Definition](https://troubleshoot.sh/docs/collect/mysql/)