### PR TITLE
Fixed the URI function to act according to Mysql/Postgres rules

### DIFF
--- a/packages/datajoint-core/src/connection/settings.rs
+++ b/packages/datajoint-core/src/connection/settings.rs
@@ -53,16 +53,16 @@ impl ConnectionSettings {
                 tls_ssl = "tls";
             }
         }
-        if self.username.trim().is_empty() == false {
-            uri = format!("{}{}", uri, self.username);
-            if self.password.trim().is_empty() == false {
+        if !self.username.trim().is_empty() {
+            uri.push_str(self.username.as_str());
+            if !self.password.trim().is_empty() {
                 uri = format!("{}:{}", uri, self.password);
             }
-            uri = format!("{}@", uri);
+            uri.push('@');
         }
         // Based on the defaults, hostname and port will always have values
         uri = format!("{}{}:{}", uri, self.hostname, self.port);
-        if self.database_name.trim().is_empty() == false {
+        if !self.database_name.trim().is_empty() {
             uri = format!("{}/{}", uri, self.database_name);
         }
 


### PR DESCRIPTION
Corresponds to #69 , but this was before we knew the extent of what the URI could be.

The uri function was extremely limited before, and did not allow for all the different types of uri that can be done in either Postgres or MySql. This tries to fix that.

Tried to follow these rules as closely as possible

MySql:

- [MySql URI rules](https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html)
-  [scheme://][user[:[password]]@]host[:port][/schema][?attribute1=value1&attribute2=value2...

Postgres:
- [Postgres URI rules](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)