### PR TITLE
Support null decoding over the C FFI

### DIFF
--- a/datajoint-python/.env
+++ b/datajoint-python/.env
@@ -1,5 +1,0 @@
-DJ_HOST=tutorial-db.datajoint.io
-PORT=3306
-DJ_USER=jonathan
-DJ_PASS=testpassword123
-DB_NAME=jonathan_tutorial

--- a/datajoint-python/.env
+++ b/datajoint-python/.env
@@ -1,0 +1,5 @@
+DJ_HOST=tutorial-db.datajoint.io
+PORT=3306
+DJ_USER=jonathan
+DJ_PASS=testpassword123
+DB_NAME=jonathan_tutorial

--- a/datajoint-python/datajoint/table_row.py
+++ b/datajoint-python/datajoint/table_row.py
@@ -90,7 +90,7 @@ class TableRow:
                 col_name = col.name()
                 # Decode the value to a Python value.
                 dj_type = dj_core.allocated_decoded_value_type(value)
-                if dj_type == dj_core.NativeTypeEnum_None:
+                if dj_type == dj_core.NativeTypeEnum_None or dj_type == dj_core.NativeTypeEnum_Null:
                     result[col_name] = None
                 elif dj_type == dj_core.NativeTypeEnum_Bool:
                     result[col_name] = ffi.cast(

--- a/packages/datajoint-core-ffi-c/src/types/decode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/decode.rs
@@ -24,9 +24,14 @@ pub unsafe extern "C" fn table_row_decode_to_buffer(
         return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
             as i32;
     }
-    match (*this).try_decode(*column) {
+    match (*this).try_decode_optional(*column) {
         Err(err) => datajoint_core_set_last_error(err) as i32,
-        Ok(result) => match result {
+        Ok(None) => {
+            *output_size = 0;
+            *output_type = NativeTypeEnum::Null;
+            ErrorCode::Success as i32
+        }
+        Ok(Some(result)) => match result {
             NativeType::None => ErrorCode::ValueDecodeError as i32,
             // No macro for generating these because of cbindgen limitations.
             NativeType::Bool(value) => {
@@ -328,7 +333,7 @@ impl AllocatedDecodedValue {
         //
         // This value cannot be set, by any means, by the outside world.
         match self.type_name {
-            NativeTypeEnum::None => (),
+            NativeTypeEnum::None | NativeTypeEnum::Null => (),
             NativeTypeEnum::Bool => {
                 Box::from_raw(self.data as *mut bool);
             }
@@ -420,6 +425,13 @@ pub unsafe extern "C" fn allocated_decoded_value_type(
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn allocated_decoded_value_is_null_value(
+    this: *const AllocatedDecodedValue,
+) -> i32 {
+    (this.is_null() || (*this).type_name == NativeTypeEnum::Null) as i32
+}
+
 /// Decodes a single table row value to a Rust-allocated buffer stored in a
 /// caller-allocated wrapper value.
 ///
@@ -439,9 +451,13 @@ pub extern "C" fn table_row_decode_to_allocation(
 
     unsafe {
         (*value).reset();
-        match (*this).try_decode(*column) {
+        match (*this).try_decode_optional(*column) {
             Err(err) => datajoint_core_set_last_error(err) as i32,
-            Ok(res) => match res {
+            Ok(None) => {
+                (*value).type_name = NativeTypeEnum::Null;
+                ErrorCode::Success as i32
+            }
+            Ok(Some(res)) => match res {
                 NativeType::None => {
                     datajoint_core_set_last_error(DataJointError::new(ErrorCode::ValueDecodeError))
                         as i32

--- a/packages/datajoint-core-ffi-c/src/types/encode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/encode.rs
@@ -12,6 +12,7 @@ impl NativeTypeEnum {
         }
         match self {
             NativeTypeEnum::None => Ok(NativeType::None),
+            NativeTypeEnum::Null => Ok(NativeType::None),
             NativeTypeEnum::Bool => Ok(NativeType::Bool(*data.cast::<bool>())),
             NativeTypeEnum::Int8 => Ok(NativeType::Int8(*data.cast::<i8>())),
             NativeTypeEnum::UInt8 => Ok(NativeType::UInt8(*data.cast::<u8>())),

--- a/packages/datajoint-core-ffi-c/src/types/native_type.rs
+++ b/packages/datajoint-core-ffi-c/src/types/native_type.rs
@@ -1,11 +1,17 @@
 /// Native types that can be decoded from a database or encoded to a query,
 /// possibly for a placeholder argument.
 ///
-/// Should be parallel to `datajoint_core::types::NativeType`.
+/// Should be parallel to `datajoint_core::types::NativeType`, aside from the
+/// additional variant to represent null.
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum NativeTypeEnum {
+    /// Represents the complete absence of any value.
     None,
+
+    /// Represents a null value.
+    Null,
+
     Bool,
     Int8,
     UInt8,

--- a/packages/datajoint-core/src/error/codes.rs
+++ b/packages/datajoint-core/src/error/codes.rs
@@ -35,6 +35,8 @@ pub enum ErrorCode {
     NoMoreRows,
     UnsupportedNativeType,
     WrongDatabaseType,
+    UnexpectedNullValue,
+    UnexpectedNoneType,
 
     // C FFI error codes.
     NullNotAllowed,
@@ -76,6 +78,8 @@ impl ErrorCode {
             NoMoreRows => "no more rows",
             UnsupportedNativeType => "unsupported native type",
             WrongDatabaseType => "wrong database type",
+            UnexpectedNullValue => "unexpected null value encountered in decoding",
+            UnexpectedNoneType => "unexpected none type encountered in encoding",
 
             NullNotAllowed => "null not allowed",
             BufferNotEnough => "buffer not enough",

--- a/packages/datajoint-core/src/error/error.rs
+++ b/packages/datajoint-core/src/error/error.rs
@@ -71,6 +71,7 @@ impl LibraryError for SqlxError {
                 index: _,
                 source: _,
             } => ErrorCode::ColumnDecodeError,
+            sqlx::Error::Decode(_) => ErrorCode::ColumnDecodeError,
             sqlx::Error::PoolTimedOut => ErrorCode::PoolTimedOut,
             sqlx::Error::PoolClosed => ErrorCode::PoolClosed,
             sqlx::Error::WorkerCrashed => ErrorCode::WorkerCrashed,

--- a/packages/datajoint-core/src/placeholders/ph_vec.rs
+++ b/packages/datajoint-core/src/placeholders/ph_vec.rs
@@ -22,7 +22,9 @@ impl PlaceholderArgumentCollection for PlaceholderArgumentVector {
             Query::MySql(mut query) => {
                 for arg in self {
                     match arg {
-                        NativeType::None => {}
+                        NativeType::None => {
+                            return Err(DataJointError::new(ErrorCode::UnexpectedNoneType))
+                        }
                         NativeType::Bool(val) => query = query.bind(val),
                         NativeType::Int8(val) => query = query.bind(val),
                         NativeType::UInt8(val) => query = query.bind(val),
@@ -43,7 +45,9 @@ impl PlaceholderArgumentCollection for PlaceholderArgumentVector {
             Query::Postgres(mut query) => {
                 for arg in self {
                     match arg {
-                        NativeType::None => {}
+                        NativeType::None => {
+                            return Err(DataJointError::new(ErrorCode::UnexpectedNoneType))
+                        }
                         NativeType::Bool(val) => query = query.bind(val),
                         NativeType::Int8(val) => query = query.bind(val),
                         NativeType::Int16(val) => query = query.bind(val),


### PR DESCRIPTION
This PR supports decoding null values from table rows by using the new `NativeTypeEnum::Null` variant.

### Core Library
The core library already supports decoding null values using `TableRow::get<T>` where `T` is an `Option` type. However, null values were being reported as SQLx errors when using `TableRow::try_decode`. The decode function has been converted to strictly use `Option<T>` types for decode results. Two interfaces are then exposed: `TableRow::try_decode`, which does not allow null values, and `TableRow::try_decode_optional`, which allows null values.

### C FFI
The C FFI only calls `TableRow::try_decode_optional` under the hood in its decode methods. Since we are returning the type of the decoded value to the caller, it makes sense to add a variant that communicates when a value was found to be null. This new variant is different from the `None` variant in its use case:
- `NativeTypeEnum::None` - Represents the complete absence of a value, meaning no decoding has or did take place.
- `NativeTypeEnum::Null` - Represents an actual `null` value retrieved from the database.

Both variants, however, are encoded back into `NativeType::None` when sent to the core library.

Calling libraries only need to handle when the output type of decode functions is `NativeTypeEnum::Null` to use this new functionality.