### PR TITLE
Refactoring UTF-8 strings and primitive enum error checks

### DIFF
--- a/packages/datajoint-core-ffi-c/Cargo.toml
+++ b/packages/datajoint-core-ffi-c/Cargo.toml
@@ -14,3 +14,5 @@ cbindgen = "0.20.0"
 [dependencies]
 datajoint-core = { path = "../datajoint-core" }
 libc = "0.2.101"
+num-derive = "0.3.3"
+num-traits = "0.2.1"

--- a/packages/datajoint-core-ffi-c/src/connection/connection.rs
+++ b/packages/datajoint-core-ffi-c/src/connection/connection.rs
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn connection_execute_query(
     let connection = &mut *this;
     let query_str = match CStr::from_ptr(query).to_str() {
         Err(_) => {
-            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidCString))
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
                 as i32
         }
         Ok(value) => value,
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn connection_fetch_query(
     let connection = &mut *this;
     let query_str = match CStr::from_ptr(query).to_str() {
         Err(_) => {
-            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidCString))
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
                 as i32
         }
         Ok(value) => value,

--- a/packages/datajoint-core-ffi-c/src/connection/settings.rs
+++ b/packages/datajoint-core-ffi-c/src/connection/settings.rs
@@ -1,6 +1,9 @@
+use crate::error::datajoint_core_set_last_error;
 use crate::util::OptionalBool;
 use datajoint_core::common::DatabaseType;
 use datajoint_core::connection::ConnectionSettings;
+use datajoint_core::error::{DataJointError, ErrorCode};
+use datajoint_core::util::IntegerEnum;
 use libc::c_char;
 use std::ffi::{CStr, CString};
 use std::ptr;
@@ -21,94 +24,133 @@ pub unsafe extern "C" fn connection_settings_free(this: *mut ConnectionSettings)
 pub unsafe extern "C" fn connection_settings_set_database_type(
     this: *mut ConnectionSettings,
     dbtype: DatabaseType,
-) {
+) -> i32 {
     if this.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
+    } else if DatabaseType::from_int(dbtype as i32) == None {
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::BadPrimitiveEnumValue))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
+    let settings: &mut ConnectionSettings = { &mut *this };
 
-    connection.database_type = dbtype;
+    settings.database_type = dbtype;
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_settings_set_username(
     this: *mut ConnectionSettings,
     username: *const c_char,
-) {
+) -> i32 {
     if this.is_null() || username.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
+    let settings: &mut ConnectionSettings = { &mut *this };
 
-    let user = CStr::from_ptr(username).to_string_lossy().to_owned();
-    connection.username = user.to_string();
+    settings.username = match CStr::from_ptr(username).to_str() {
+        Err(_) => {
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
+                as i32
+        }
+        Ok(cstr) => cstr.to_string(),
+    };
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_settings_set_password(
     this: *mut ConnectionSettings,
     password: *const c_char,
-) {
+) -> i32 {
     if this.is_null() || password.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
+    let settings: &mut ConnectionSettings = { &mut *this };
 
-    let pass = CStr::from_ptr(password).to_string_lossy().to_owned();
-    connection.password = pass.to_string();
+    settings.password = match CStr::from_ptr(password).to_str() {
+        Err(_) => {
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
+                as i32
+        }
+        Ok(cstr) => cstr.to_string(),
+    };
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_settings_set_hostname(
     this: *mut ConnectionSettings,
     hostname: *const c_char,
-) {
+) -> i32 {
     if this.is_null() || hostname.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
+    let settings: &mut ConnectionSettings = { &mut *this };
 
-    let host = CStr::from_ptr(hostname).to_string_lossy().to_owned();
-    connection.hostname = host.to_string();
+    settings.hostname = match CStr::from_ptr(hostname).to_str() {
+        Err(_) => {
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
+                as i32
+        }
+        Ok(cstr) => cstr.to_string(),
+    };
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn connection_settings_set_port(this: *mut ConnectionSettings, port: u16) {
+pub unsafe extern "C" fn connection_settings_set_port(
+    this: *mut ConnectionSettings,
+    port: u16,
+) -> i32 {
     if this.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
-    connection.port = port;
+    let settings: &mut ConnectionSettings = { &mut *this };
+    settings.port = port;
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_settings_set_database_name(
     this: *mut ConnectionSettings,
     database_name: *const c_char,
-) {
+) -> i32 {
     if this.is_null() || database_name.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
+    let settings: &mut ConnectionSettings = { &mut *this };
 
-    let database = CStr::from_ptr(database_name).to_string_lossy().to_owned();
-    connection.database_name = database.to_string();
+    settings.database_name = match CStr::from_ptr(database_name).to_str() {
+        Err(_) => {
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
+                as i32
+        }
+        Ok(cstr) => cstr.to_string(),
+    };
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_settings_set_use_tls(
     this: *mut ConnectionSettings,
-    tls_ssl: OptionalBool,
-) {
+    use_tls: OptionalBool,
+) -> i32 {
     if this.is_null() {
-        return;
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::NullNotAllowed))
+            as i32;
+    } else if OptionalBool::from_int(use_tls as i32) == None {
+        return datajoint_core_set_last_error(DataJointError::new(ErrorCode::BadPrimitiveEnumValue))
+            as i32;
     }
-    let connection: &mut ConnectionSettings = { &mut *this };
-    match tls_ssl {
-        OptionalBool::True => connection.use_tls = Some(true),
-        OptionalBool::False => connection.use_tls = Some(false),
-        OptionalBool::None => connection.use_tls = None,
-    }
+    let settings: &mut ConnectionSettings = { &mut *this };
+    settings.use_tls = use_tls.into();
+    ErrorCode::Success as i32
 }
 
 #[no_mangle]
@@ -116,12 +158,13 @@ pub unsafe extern "C" fn connection_settings_get_database_type(
     this: *mut ConnectionSettings,
 ) -> DatabaseType {
     if this.is_null() {
-        // TODO: Return a different default value?
+        // Just return a default value since there is no way of representing the
+        // absence of a value with an enum.
         return DatabaseType::MySql;
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    connection.database_type
+    settings.database_type
 }
 
 #[no_mangle]
@@ -131,10 +174,9 @@ pub unsafe extern "C" fn connection_settings_get_username(
     if this.is_null() {
         return ptr::null();
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    let str_bytes = connection.username.as_bytes();
-    match CString::new(str_bytes) {
+    match CString::new(settings.username.as_bytes()) {
         Err(_) => std::ptr::null(),
         Ok(str_bytes) => str_bytes.into_raw(),
     }
@@ -147,10 +189,9 @@ pub unsafe extern "C" fn connection_settings_get_password(
     if this.is_null() {
         return ptr::null();
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    let str_bytes = connection.password.as_bytes();
-    match CString::new(str_bytes) {
+    match CString::new(settings.password.as_bytes()) {
         Err(_) => std::ptr::null(),
         Ok(str_bytes) => str_bytes.into_raw(),
     }
@@ -163,10 +204,9 @@ pub unsafe extern "C" fn connection_settings_get_hostname(
     if this.is_null() {
         return ptr::null();
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    let str_bytes = connection.hostname.as_bytes();
-    match CString::new(str_bytes) {
+    match CString::new(settings.hostname.as_bytes()) {
         Err(_) => std::ptr::null(),
         Ok(str_bytes) => str_bytes.into_raw(),
     }
@@ -177,9 +217,9 @@ pub unsafe extern "C" fn connection_settings_get_port(this: *const ConnectionSet
     if this.is_null() {
         return 0;
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    connection.port
+    settings.port
 }
 
 #[no_mangle]
@@ -189,10 +229,9 @@ pub unsafe extern "C" fn connection_settings_get_database_name(
     if this.is_null() {
         return ptr::null();
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    let str_bytes = connection.database_name.as_bytes();
-    match CString::new(str_bytes) {
+    match CString::new(settings.database_name.as_bytes()) {
         Err(_) => std::ptr::null(),
         Ok(str_bytes) => str_bytes.into_raw(),
     }
@@ -205,11 +244,7 @@ pub unsafe extern "C" fn connection_settings_get_use_tls(
     if this.is_null() {
         return OptionalBool::None;
     }
-    let connection: &ConnectionSettings = { &*this };
+    let settings: &ConnectionSettings = { &*this };
 
-    match connection.use_tls {
-        Some(true) => OptionalBool::True,
-        Some(false) => OptionalBool::False,
-        None => OptionalBool::None,
-    }
+    OptionalBool::from_option(settings.use_tls)
 }

--- a/packages/datajoint-core-ffi-c/src/lib.rs
+++ b/packages/datajoint-core-ffi-c/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate datajoint_core;
+#[macro_use]
+extern crate num_derive;
 
 mod connection;
 mod error;

--- a/packages/datajoint-core-ffi-c/src/results/table_row.rs
+++ b/packages/datajoint-core-ffi-c/src/results/table_row.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn table_row_get_column_with_name(
 
     let column_name = match CStr::from_ptr(column_name).to_str() {
         Err(_) => {
-            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidCString))
+            return datajoint_core_set_last_error(DataJointError::new(ErrorCode::InvalidUtf8String))
                 as i32
         }
         Ok(string) => string,

--- a/packages/datajoint-core-ffi-c/src/types/decode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/decode.rs
@@ -534,7 +534,7 @@ pub extern "C" fn table_row_decode_to_allocation(
                     (*value).type_name = NativeTypeEnum::String;
                     match CString::new(string) {
                         Err(_) => datajoint_core_set_last_error(DataJointError::new(
-                            ErrorCode::InvalidCString,
+                            ErrorCode::InvalidUtf8String,
                         )) as i32,
                         Ok(cstr) => {
                             (*value).data = cstr.into_raw() as *const c_void;

--- a/packages/datajoint-core-ffi-c/src/types/encode.rs
+++ b/packages/datajoint-core-ffi-c/src/types/encode.rs
@@ -24,7 +24,7 @@ impl NativeTypeEnum {
             NativeTypeEnum::UInt64 => Ok(NativeType::UInt64(*data.cast::<u64>())),
             NativeTypeEnum::String => {
                 let str = match CStr::from_ptr(data as *const _).to_str() {
-                    Err(_) => return Err(DataJointError::new(ErrorCode::InvalidCString)),
+                    Err(_) => return Err(DataJointError::new(ErrorCode::InvalidUtf8String)),
                     Ok(str) => str,
                 };
                 Ok(NativeType::String(str.to_string()))

--- a/packages/datajoint-core-ffi-c/src/types/native_type.rs
+++ b/packages/datajoint-core-ffi-c/src/types/native_type.rs
@@ -1,10 +1,13 @@
+use datajoint_core::util::IntegerEnum;
+use num_traits::FromPrimitive;
+
 /// Native types that can be decoded from a database or encoded to a query,
 /// possibly for a placeholder argument.
 ///
 /// Should be parallel to `datajoint_core::types::NativeType`, aside from the
 /// additional variant to represent null.
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, FromPrimitive)]
 pub enum NativeTypeEnum {
     /// Represents the complete absence of any value.
     None,
@@ -25,4 +28,10 @@ pub enum NativeTypeEnum {
     Float32,
     Float64,
     Bytes,
+}
+
+impl IntegerEnum<i32> for NativeTypeEnum {
+    fn from_int(val: i32) -> Option<Self> {
+        FromPrimitive::from_i32(val)
+    }
 }

--- a/packages/datajoint-core-ffi-c/src/util/boolenum.rs
+++ b/packages/datajoint-core-ffi-c/src/util/boolenum.rs
@@ -1,8 +1,37 @@
-// Enum for setters and getters in connection/settings.rs. Used instead of a Option<bool>.
+use datajoint_core::util::IntegerEnum;
+use num_traits::FromPrimitive;
+
+/// Enum for setters and getters in connection/settings.rs. Used instead of a Option<bool>.
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, FromPrimitive)]
 pub enum OptionalBool {
-    True,
-    False,
-    None,
+    None = -1,
+    False = 0,
+    True = 1,
+}
+
+impl OptionalBool {
+    /// Converts the enum into its Rust type.
+    pub fn into(self) -> Option<bool> {
+        match self {
+            OptionalBool::None => None,
+            OptionalBool::False => Some(false),
+            OptionalBool::True => Some(true),
+        }
+    }
+
+    /// Converts an optional boolean value into the enum type.
+    pub fn from_option(from: Option<bool>) -> OptionalBool {
+        match from {
+            None => OptionalBool::None,
+            Some(false) => OptionalBool::False,
+            Some(true) => OptionalBool::True,
+        }
+    }
+}
+
+impl IntegerEnum<i32> for OptionalBool {
+    fn from_int(val: i32) -> Option<Self> {
+        FromPrimitive::from_i32(val)
+    }
 }

--- a/packages/datajoint-core/src/error/codes.rs
+++ b/packages/datajoint-core/src/error/codes.rs
@@ -42,8 +42,9 @@ pub enum ErrorCode {
     NullNotAllowed,
     BufferNotEnough,
     InvalidNativeType,
-    InvalidCString,
+    InvalidUtf8String,
     RowIndexOutOfBounds,
+    BadPrimitiveEnumValue,
 }
 
 impl Display for ErrorCode {
@@ -84,8 +85,9 @@ impl ErrorCode {
             NullNotAllowed => "null not allowed",
             BufferNotEnough => "buffer not enough",
             InvalidNativeType => "invalid native type",
-            InvalidCString => "invalid c string",
+            InvalidUtf8String => "invalid utf-8 string",
             RowIndexOutOfBounds => "row index out of bounds",
+            BadPrimitiveEnumValue => "bad primitive enum value",
         }
     }
 }


### PR DESCRIPTION
Closes #76 

Assure all UTF-8 strings passed in and out of the C FFI are handled consistently, and check all input primitive enum types into the C FFI, throwing an appropriate error to avoid undefined behavior.