### PR TITLE
Add binary, attach, and decimal types.

### DIFF
--- a/packages/datajoint-core/Cargo.toml
+++ b/packages/datajoint-core/Cargo.toml
@@ -10,4 +10,4 @@ futures-core = { version = "0.3.1" }
 num-derive = "0.3.3"
 num-traits = "0.2.1"
 tokio = { version = "1.11.0", features = ["full"] }
-sqlx = { version = "0.5.9", features = ["runtime-async-std-native-tls", "postgres", "mysql", "tls", "any", "chrono"]}
+sqlx = { version = "0.5.9", features = ["runtime-async-std-native-tls", "postgres", "mysql", "tls", "any", "chrono", "bigdecimal"]}

--- a/packages/datajoint-core/src/results/table_column.rs
+++ b/packages/datajoint-core/src/results/table_column.rs
@@ -89,6 +89,8 @@ impl<'r> TableColumnRef<'r> {
                 "MEDIUMBLOB" => MediumBlob,
                 "BLOB" => Blob,
                 "LONGBLOB" => LongBlob,
+                "BINARY" => Binary,
+                "VARBINARY" => Binary,
                 &_ => Unknown,
             },
             Self::Postgres(column) => {
@@ -102,16 +104,19 @@ impl<'r> TableColumnRef<'r> {
                         "CHAR" => CharN,
                         "VARCHAR" => VarCharN,
                         "TEXT" => VarCharN,
-                        "BYTEA" => LongBlob,
+                        "BYTEA" => Binary,
                         "FLOAT4" => Float,
                         "FLOAT8" => Double,
                         "DATE" => Date,
                         "TIME" => Time,
                         "TIMESTAMP" => DateTime,
                         "TIMESTAMPTZ" => Timestamp,
+                        "NUMERIC" => Decimal,
                         &_ => Unknown,
                         // TODO(jackson-nestelroad): Check all of the other Postgres types at
                         // https://docs.rs/sqlx-core/0.5.9/src/sqlx_core/postgres/type_info.rs.html#447.
+                        //
+                        // It is specifically interesting how arrays might be handled.
                     },
                     _ => Unknown,
                 }

--- a/packages/datajoint-core/src/types/decode.rs
+++ b/packages/datajoint-core/src/types/decode.rs
@@ -68,12 +68,6 @@ impl TableRow {
                 "unsupported column type",
                 ErrorCode::ColumnDecodeError,
             )),
-            // Need to look at https://docs.rs/sqlx/0.5.9/sqlx/types/index.html closer
-            // for these types.
-            FilepathStore => Err(DataJointError::new_with_message(
-                "supported column type, but no decoder implemented",
-                ErrorCode::ColumnDecodeError,
-            )),
             Boolean => Ok(match self.try_get::<Option<bool>, usize>(index)? {
                 None => None,
                 Some(val) => Some(NativeType::Bool(val)),
@@ -154,7 +148,7 @@ impl TableRow {
                 None => None,
                 Some(val) => Some(NativeType::Float64(val)),
             }),
-            TinyBlob | MediumBlob | Blob | LongBlob | Binary | Attach => Ok(match self.try_get::<Option<Vec<u8>>, usize>(index)? {
+            TinyBlob | MediumBlob | Blob | LongBlob | Binary => Ok(match self.try_get::<Option<Vec<u8>>, usize>(index)? {
                 None => None,
                 Some(val) => Some(NativeType::Bytes(val)),
             }),

--- a/packages/datajoint-core/src/types/decode.rs
+++ b/packages/datajoint-core/src/types/decode.rs
@@ -70,7 +70,7 @@ impl TableRow {
             )),
             // Need to look at https://docs.rs/sqlx/0.5.9/sqlx/types/index.html closer
             // for these types.
-            Decimal | Attach | FilepathStore => Err(DataJointError::new_with_message(
+            FilepathStore => Err(DataJointError::new_with_message(
                 "supported column type, but no decoder implemented",
                 ErrorCode::ColumnDecodeError,
             )),
@@ -154,9 +154,13 @@ impl TableRow {
                 None => None,
                 Some(val) => Some(NativeType::Float64(val)),
             }),
-            TinyBlob | MediumBlob | Blob | LongBlob => Ok(match self.try_get::<Option<Vec<u8>>, usize>(index)? {
+            TinyBlob | MediumBlob | Blob | LongBlob | Binary | Attach => Ok(match self.try_get::<Option<Vec<u8>>, usize>(index)? {
                 None => None,
                 Some(val) => Some(NativeType::Bytes(val)),
+            }),
+            Decimal => Ok(match self.try_get::<Option<sqlx::types::BigDecimal>, usize>(index)? {
+                None => None,
+                Some(val) => Some(NativeType::String(val.to_string())),
             }),
         }
     }

--- a/packages/datajoint-core/src/types/types.rs
+++ b/packages/datajoint-core/src/types/types.rs
@@ -28,6 +28,7 @@ pub enum DataJointType {
     MediumBlob,
     Blob,
     LongBlob,
+    Binary,
     Attach,
     FilepathStore,
 }

--- a/packages/datajoint-core/src/types/types.rs
+++ b/packages/datajoint-core/src/types/types.rs
@@ -29,6 +29,4 @@ pub enum DataJointType {
     Blob,
     LongBlob,
     Binary,
-    Attach,
-    FilepathStore,
 }


### PR DESCRIPTION
This PR adds support for three DataJoint types:
- Binary, which represents a binary string of data.
- Decimal, which represents an arbitrary numeric value.
- Attach, which represents an internal file.