### PR TITLE
Only pin query string rather than entire cursor

### DIFF
--- a/packages/datajoint-core-ffi-c/src/connection/cursor.rs
+++ b/packages/datajoint-core-ffi-c/src/connection/cursor.rs
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn cursor_next(this: *mut Cursor, out: *mut *mut TableRow)
             as i32;
     }
     let cursor = &mut *this;
-    match std::pin::Pin::as_mut(cursor).get_unchecked_mut().try_next() {
+    match cursor.try_next() {
         Err(error) => datajoint_core_set_last_error(error) as i32,
         Ok(value) => {
             util::mem::handle_output_ptr(out, value);
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn cursor_rest(this: *mut Cursor, out: *mut *mut TableRowV
             as i32;
     }
     let cursor = &mut *this;
-    match std::pin::Pin::as_mut(cursor).get_unchecked_mut().try_rest() {
+    match cursor.try_rest() {
         Err(error) => datajoint_core_set_last_error(error) as i32,
         Ok(value) => {
             util::mem::handle_output_ptr(out, TableRowVector::new(value));

--- a/packages/datajoint-core/src/connection/connection.rs
+++ b/packages/datajoint-core/src/connection/connection.rs
@@ -1,6 +1,6 @@
 use crate::common::{DatabaseType, DatabaseTypeAgnostic};
 use crate::connection::Pool;
-use crate::connection::{ConnectionSettings, Cursor, Executor, NativeCursor};
+use crate::connection::{ConnectionSettings, Cursor, Executor};
 use crate::error::{DataJointError, Error, ErrorCode, SqlxError};
 use crate::placeholders::{PlaceholderArgumentCollection, PlaceholderArgumentVector};
 
@@ -186,7 +186,7 @@ impl Connection {
 
     /// Creates a cursor for iterating over the results of the given returning query.
     pub fn try_fetch_query<'c>(&'c self, query: &str) -> Result<Cursor<'c>, Error> {
-        NativeCursor::new_from_executor(
+        Cursor::new_from_executor(
             query,
             self.try_executor()?,
             None as Option<PlaceholderArgumentVector>,
@@ -201,6 +201,6 @@ impl Connection {
         query: &'c str,
         args: impl PlaceholderArgumentCollection,
     ) -> Result<Cursor, Error> {
-        NativeCursor::new_from_executor(query, self.try_executor()?, Some(args))
+        Cursor::new_from_executor(query, self.try_executor()?, Some(args))
     }
 }

--- a/packages/datajoint-core/src/connection/executor.rs
+++ b/packages/datajoint-core/src/connection/executor.rs
@@ -1,5 +1,5 @@
 use crate::common::{DatabaseType, DatabaseTypeAgnostic};
-use crate::connection::{Cursor, NativeCursor, Pool};
+use crate::connection::{Cursor, Pool};
 use crate::error::Error;
 use crate::placeholders::{PlaceholderArgumentCollection, PlaceholderArgumentVector};
 use crate::query::Query;
@@ -99,7 +99,7 @@ impl<'c> Executor<'c> {
 
     /// Creates a cursor for the given query.
     pub fn cursor(&'c self, query: &str) -> Result<Cursor<'c>, Error> {
-        NativeCursor::new_from_executor_ref(query, &self, None as Option<PlaceholderArgumentVector>)
+        Cursor::new_from_executor_ref(query, &self, None as Option<PlaceholderArgumentVector>)
     }
 
     /// Creates a cursor for the given query.
@@ -110,6 +110,6 @@ impl<'c> Executor<'c> {
         query: &str,
         args: impl PlaceholderArgumentCollection,
     ) -> Result<Cursor<'c>, Error> {
-        NativeCursor::new_from_executor_ref(query, self, Some(args))
+        Cursor::new_from_executor_ref(query, self, Some(args))
     }
 }

--- a/packages/datajoint-core/src/connection/mod.rs
+++ b/packages/datajoint-core/src/connection/mod.rs
@@ -5,7 +5,7 @@ mod pool;
 mod settings;
 
 pub use connection::Connection;
-pub use cursor::{Cursor, NativeCursor};
+pub use cursor::Cursor;
 pub use executor::Executor;
 pub(crate) use pool::Pool;
 pub use settings::ConnectionSettings;


### PR DESCRIPTION
This PR fixes a bug that forced all calls to `Cursor::next` and `Cursor::rest` to be unsafe due to the cursor being pinned to memory. To fix this problem, only the query string is pinned in memory to keep a valid reference to it in the SQLx query.